### PR TITLE
Changed MongoCursor constructor to native

### DIFF
--- a/src/mongoCursor.php
+++ b/src/mongoCursor.php
@@ -70,13 +70,11 @@ class MongoCursor {
    *
    * @return  - Returns the new cursor.
    */
+  <<__Native>>
   public function __construct(MongoClient $connection,
                               string $ns,
                               array $query = array(),
-                              array $fields = array()) {
-    
-    printf("Constructing MongoCursor\n");
-  }
+                              array $fields = array());
 
   /**
    * Counts the number of results for this query


### PR DESCRIPTION
This would get rid of the warning: ‘void HPHP::c_MongoCursor_ni___construct(HPHP::CObjRef, const HPHP::Object&, const HPHP::String&, const HPHP::Array&, const HPHP::Array&)’ defined but not used [-Wunused-function] in the current master branch.
