### PR TITLE
Added return type to constructor in mongoCursor.php, added __construct t...

### DIFF
--- a/src/mongoCursor.cpp
+++ b/src/mongoCursor.cpp
@@ -181,6 +181,7 @@ static bool HHVM_METHOD(MongoCursor, valid) {
 ////////////////////////////////////////////////////////////////////////////////
 
 void mongoExtension::_initMongoCursorClass() {
+    HHVM_ME(MongoCursor, __construct);
     HHVM_ME(MongoCursor, addOption);
     HHVM_ME(MongoCursor, awaitData);
     HHVM_ME(MongoCursor, batchSize);

--- a/src/mongoCursor.php
+++ b/src/mongoCursor.php
@@ -74,7 +74,7 @@ class MongoCursor {
   public function __construct(MongoClient $connection,
                               string $ns,
                               array $query = array(),
-                              array $fields = array());
+                              array $fields = array()): void;
 
   /**
    * Counts the number of results for this query


### PR DESCRIPTION
...o initMongoCursorClass(). Passed test.sh.

This should fix the segfault error when running ./test.sh on master branch.
