### PR TITLE
Use which to find phpunit binary

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,5 +11,5 @@ mongoimport --db test --collection students --file test/students.json --upsert
 
 ${HPHP_HOME}/hphp/hhvm/hhvm \
   -vDynamicExtensions.0=${DIRNAME}/mongo.so \
-  /usr/local/bin/phpunit ${DIRNAME}/test
+  `which phpunit` ${DIRNAME}/test
 


### PR DESCRIPTION
This is more portable than a hard-coded path to PHPUnit.

Original path was added in https://github.com/10gen-labs/mongo-hhvm-driver/commit/9f4a14c0e4490701b3ebc5c85ddfa0d6b137278f (part of #12).
