### PR TITLE
Fix undefined MongoClient in HHVM 3.1 and Ubuntu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ if [ "$HPHP_HOME" = "" ]; then
     exit 1
 fi
 
-printf "<?hh\n" > mongo.php
-tail -q -n +2 src/*php src/types/*php src/exceptions/*php >> mongo.php
+printf "<?hh\n" > ext_mongo.php
+tail -q -n +2 src/*php src/types/*php src/exceptions/*php >> ext_mongo.php
 
 $HPHP_HOME/hphp/tools/hphpize/hphpize
 cmake .

--- a/config.cmake
+++ b/config.cmake
@@ -25,7 +25,7 @@ ENDIF()
 include_directories(${MONGOC_INCLUDE_DIR})
 include_directories(${BSON_INCLUDE_DIR})
 
-HHVM_EXTENSION(mongo src/ext_mongo.cpp src/mongo_common.cpp src/mongoClient.cpp src/mongoCursor.cpp src/mongoCollection.cpp src/bson.cpp src/bson_decode.cpp src/contrib/encode.cpp)
-HHVM_SYSTEMLIB(mongo mongo.php)
+HHVM_EXTENSION(mongo src/mongo_common.cpp src/ext_mongo.cpp src/mongoClient.cpp src/mongoCursor.cpp src/mongoCollection.cpp src/bson.cpp src/bson_decode.cpp src/contrib/encode.cpp)
+HHVM_SYSTEMLIB(mongo ext_mongo.php)
 
 target_link_libraries(mongo ${MONGOC_LIBRARY})

--- a/src/bson.cpp
+++ b/src/bson.cpp
@@ -20,7 +20,7 @@ namespace HPHP {
         return encode(value);
     }
 
-    void mongoExtension::_initBSON() {
+    void MongoExtension::_initBSON() {
         HHVM_FE(bson_decode);
         HHVM_FE(bson_encode);
     }

--- a/src/ext_mongo.cpp
+++ b/src/ext_mongo.cpp
@@ -14,7 +14,32 @@ HPHP::Class* MongoProtocolException::cls = nullptr;
 HPHP::Class* MongoResultException::cls = nullptr;
 HPHP::Class* MongoWriteConcernException::cls = nullptr;
 
-mongoExtension s_mongo_extension;
+HPHP::Class* MongoClient::cls = nullptr;
+HPHP::Class* MongoCursor::cls = nullptr;
+HPHP::Class* MongoCollection::cls = nullptr;
+
+static void mongoc_log_handler(mongoc_log_level_t log_level,
+                               const char *log_domain, const char *message,
+                               void *user_data) {
+   if (log_level < MONGOC_LOG_LEVEL_INFO) {
+      mongoc_log_default_handler(log_level, log_domain, message, NULL);
+   }
+}
+
+MongoExtension::MongoExtension() :
+  Extension("mongo") {
+}
+
+void MongoExtension::moduleInit() {
+  mongoc_log_set_handler(mongoc_log_handler, NULL);
+  _initMongoClientClass();
+  _initMongoCursorClass();
+  _initMongoCollectionClass();
+  _initBSON();
+  loadSystemlib();
+}
+
+MongoExtension s_mongo_extension;
 HHVM_GET_MODULE(mongo);
 
 } // namespace HPHP

--- a/src/ext_mongo.h
+++ b/src/ext_mongo.h
@@ -45,6 +45,10 @@ MONGO_DEFINE_CLASS(MongoProtocolException)
 MONGO_DEFINE_CLASS(MongoResultException)
 MONGO_DEFINE_CLASS(MongoWriteConcernException)
 
+MONGO_DEFINE_CLASS(MongoClient)
+MONGO_DEFINE_CLASS(MongoCursor)
+MONGO_DEFINE_CLASS(MongoCollection)
+
 #undef MONGO_DEFINE_CLASS
 
 template<typename T>
@@ -58,26 +62,10 @@ void mongoThrow(const char* message) {
 
 //////////////////////////////////////////////////////////////////////////////
 
-static void mongoc_log_handler(mongoc_log_level_t log_level,
-                               const char *log_domain, const char *message,
-                               void *user_data) {
-   if (log_level < MONGOC_LOG_LEVEL_INFO) {
-      mongoc_log_default_handler(log_level, log_domain, message, NULL);
-   }
-}
-
-class mongoExtension : public Extension {
+class MongoExtension : public Extension {
 public:
-  mongoExtension() : Extension("mongo") {}
-  virtual void moduleInit() {
-
-    mongoc_log_set_handler(mongoc_log_handler, NULL);
-    _initMongoClientClass();
-    _initMongoCursorClass();
-    _initMongoCollectionClass();
-    _initBSON();
-    loadSystemlib();
-  }
+  MongoExtension();
+  virtual void moduleInit();
 
 private:
   void _initMongoClientClass();

--- a/src/mongoClient.cpp
+++ b/src/mongoClient.cpp
@@ -106,7 +106,7 @@ static String HHVM_METHOD(MongoClient, getServerVersion) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void mongoExtension::_initMongoClientClass() {
+void MongoExtension::_initMongoClientClass() {
     HHVM_ME(MongoClient, __construct);
     HHVM_ME(MongoClient, close);
     HHVM_ME(MongoClient, connect);

--- a/src/mongoCollection.cpp
+++ b/src/mongoCollection.cpp
@@ -156,7 +156,7 @@ mongoc_collection_update (mongoc_collection_t          *collection,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void mongoExtension::_initMongoCollectionClass() {
+void MongoExtension::_initMongoCollectionClass() {
     HHVM_ME(MongoCollection, insert);
     HHVM_ME(MongoCollection, remove);
     HHVM_ME(MongoCollection, update);

--- a/src/mongoCursor.cpp
+++ b/src/mongoCursor.cpp
@@ -197,7 +197,7 @@ static bool HHVM_METHOD(MongoCursor, valid) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void mongoExtension::_initMongoCursorClass() {
+void MongoExtension::_initMongoCursorClass() {
     HHVM_ME(MongoCursor, current);
     HHVM_ME(MongoCursor, hasNext);
     HHVM_ME(MongoCursor, next);

--- a/src/mongo_common.h
+++ b/src/mongo_common.h
@@ -88,6 +88,6 @@ private:
 
 MongocCursor *get_cursor(Object obj);
 
-}
+} // namespace HPHP
 
 #endif // incl_HPHP_EXT_MONGO_COMMON_H_


### PR DESCRIPTION
This is a fix for issue #55. I haven't done any HHVM extension development until now, so I'm sorry if any of this departs from convention or doesn't make sense.

On Ubuntu and HHVM 3.1, the mongo extension would be loaded (according to `get_loaded_extensions()`) but `var_dump(new MongoClient())` would cause an exception because the class was not defined. Here are the changes I made to fix this:
- Renamed the generated `mongo.php` file to `ext_mongo.php` for consistency with other extensions and because of [this answer on SO](http://stackoverflow.com/questions/23868172/cant-load-hhvm-extension-dynamic#answer-23878380)
- Used `MONGO_DEFINE_CLASS` macro for `MongoClient`, `MongoCursor`, and `MongoCollection` (not sure if this was necessary, but the Imagick extension does this)
- Capitalized `mongoExtension` class (so now it's `MongoExtension`)
- Moved some implementation from `ext_mongo.h` to `ext_mongo.cpp`

After this change, I see the expected result in `./interactive_mode.sh`:

```
hphpd> var_dump(new MongoClient());
object(MongoClient)#1 (3) {
  ["read_preference":"MongoClient":private]=>
  array(0) {
  }
  ["databases":"MongoClient":private]=>
  array(0) {
  }
  ["__mongoc_client"]=>
  resource(4) of type (mongoc client)
}
```
